### PR TITLE
Update overtime system to reward vacation hours

### DIFF
--- a/5_People/career.md
+++ b/5_People/career.md
@@ -85,7 +85,11 @@ Read more about the careers and their roles:
 
 Each month everyone is expected to work (on average) 7.5 hours per working day in that month (lunch time not included). 
 
-Any additional hours are considered as overtime hours and are worth 130% of your hourly wage (which is your monthly salary divided by 150). Overtime is calculated on a monthly basis. Meaning in a month with 20 working days, all hours above 150 (7.5*20). Overtime cannot be calculated on a daily or weekly basis. Trialists are paid per hour and as such do not receive overtime.
+Any additional hours are considered as overtime hours and are worth 1.3 times the amount in vacation hours.
+The reason for this is that we don't want to encourage people to work overtime, however we do understand that people work best in different ways.
+Some people might prefer to work flat 7.5 hours every day while others might prefer to work long hours one month and than take it easier the following month.
+This system of rewarding overtime with vacation hours should then allow everyone to work the way they want.
+Overtime is calculated on a monthly basis and cannot be calculated on a daily or weekly basis. Meaning in a month with 20 working days, all hours above 150 (7.5*20). Trialists do not yet have vacation hours and as such are not eligible to work overtime.
 
 
 ### Tracking Actual Working Hours


### PR DESCRIPTION
As discussed on [IRL #FML](teamniteo/operations#1586 (comment)) we will, for half a year or so, try to have overtime
be rewarded with 1.3 times the amount in vacation hours instead of overtime pay.
This new system should allow all Niteans to work the way that feels best for them
without potentially affecting e.g. profit sharing.

Ref: https://github.com/teamniteo/operations/issues/1739