### PR TITLE
Add option for overtime into allowance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist/
-
+.vscode/
+.DS_Store

--- a/5_People/career.md
+++ b/5_People/career.md
@@ -83,13 +83,17 @@ Read more about the careers and their roles:
 
 ## Working Hours
 
-Each month everyone is expected to work (on average) 7.5 hours per working day in that month (lunch time not included). 
+Each month everyone is expected to work (on average) 7.5 hours per working day in that month (lunch time not included).
 
 Any additional hours are considered as overtime hours and are worth 1.3 times the amount in vacation hours.
 The reason for this is that we don't want to encourage people to work overtime, however we do understand that people work best in different ways.
-Some people might prefer to work flat 7.5 hours every day while others might prefer to work long hours one month and than take it easier the following month.
-This system of rewarding overtime with vacation hours should then allow everyone to work the way they want.
-Overtime is calculated on a monthly basis and cannot be calculated on a daily or weekly basis. Meaning in a month with 20 working days, all hours above 150 (7.5*20). Trialists do not yet have vacation hours and as such are not eligible to work overtime.
+Some people might prefer to work flat 7.5 hours every day while others might prefer to work long hours one month and then take it easier the following month.
+This system of rewarding overtime with vacation hours should allow everyone to work the way they want.
+
+Optionally, you can decide at the beginning of a quarter to have overtime hours be converted to allowance (at 100% of your hourly salary).
+
+Overtime is calculated on a monthly basis and cannot be calculated on a daily or weekly basis. Meaning in a month with 20 working days, all hours above 150 (7.5*20).
+Trialists do not yet have vacation hours or allowance and as such are not eligible to work overtime.
 
 
 ### Tracking Actual Working Hours


### PR DESCRIPTION
On IRL#10 we decided to add an option to have overtime hours be
converted into allowance at 100% of your hourly salary.
You can opt in to this system at the beginning of a quarter.

Ref: https://github.com/teamniteo/operations/issues/1858