### PR TITLE
Add Temporary Reductions to the handbook

### DIFF
--- a/5_People/reductions.md
+++ b/5_People/reductions.md
@@ -1,0 +1,32 @@
+# Temporary Reductions
+
+If the company should find itself in a situation of economic downturn, measures need to be taken in order to save money.
+
+The first step should be to reduce operating costs by looking into active services and subscriptions, reducing server costs, and other optimizations. Limitations can encourage creativity so maybe some clever permanent solutions will come out of it as well.
+
+If the above didn't reduce costs enough to prevent the downturn, a look into the other, and perhaps the biggest, part of the company's operating costs might also be necessary. Namely, salaries and benefits.
+We know that this is a subject that is difficult to approach but we believe we have found a way for Niteans to keep their jobs while still feeling appreciated for the important work that they do.
+
+Introducing deferred salaries.
+
+## Deferred Salaries
+Each permanent Nitean can choose to defer a part of their monthly salary, up to a maximum of 30%, and not get it paid out immediately. Instead, when the company is profitable, they get paid back 130% of what they deferred. Niteans can adjust the amount they defer on every IRL (twice a year).
+
+If a Nitean quits or is fired before they are paid back, they lose the 30% interest but will eventually get paid back 100% of what they risked.
+
+The company pays the deferred salaries back when there is operational profit. The profit first goes into filling up the [required reserves](profit-sharing.md#the-concept) (if needed), then half of what remains goes to paying out deferred salaries and the other half goes to standard [profit sharing](profit-sharing.md). While this system is in place, we don't pay out any donations.
+
+The maximum total deferred salaries is the average monthly loss in the last two quarters. The minimum total is half of that. If the minimum total is not reached, we will follow the plan below in order to reach it.
+
+### Theoretical Example
+A Nitean chooses to defer €1,000 of their monthly salary on IRL#N. They keep their decision until IRL#N+1 (6 months later). This means they defer 6 x €1,000 of their salary, and as such, they are eligible for a €7,800 (6 x €1,300) payout.
+In the same time period, all Niteans defer €60,000 in total.
+
+After the second profitable quarter, the company has €100,000 of profit and is €20,000 below the [required reserves](profit-sharing.md#the-concept). This leaves €40,000 for paying back deferred salaries and €40,000 for profit sharing. The Nitean's share of the deferred salaries is 13% (€7,800 / €60,000) so they get paid back €5,200 (13% x €40,000). The rest will be paid out the next time the company has profit.
+
+## Expense Reduction Plan
+1. Set a goal to save X per month.
+1. Lower monthly expenses without hurting our customers.
+1. Use deferred salaries to reach the rest of the goal.
+1. If the above still isn't enough, we will cut the monthly and/or yearly allowance budget as well as limit travel/conferences.
+1. Lastly, if needed, we decrease everyone's salary (by lowering the affordability ratio) enough to get to 100% of the goal.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The structure of the Handbook mirrors our departments for simple organization. B
   * [Career at Niteo](/5_People/career.md)
   * [Benefits](/5_People/benefits.md)
   * [Profit Sharing](/5_People/profit-sharing.md)
+  * [Temporary Reductions](/5_People/reductions.md)
 * Hiring and Onboarding
   * [Hiring](/5_People/hiring.md)
   * [Onboarding](/5_People/onboarding.md)


### PR DESCRIPTION
This commit adds a new section called `Temporary Reductions` 
which will include information about `Deferred Salaries`
and potentially reducing Allowances in times of economic downturn.

Ref: https://github.com/teamniteo/operations/issues/2083
Ref: https://github.com/teamniteo/operations/issues/2087